### PR TITLE
Expose dump function in the module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import setup, find_packages
 from sys import path as sys_path
 
 deps = [
-    "pymp4", "click"
+    "pymp4", "click", "clickutil"
 ]
 
 srcdir = join(dirname(abspath(__file__)), "src/")

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ from setuptools import setup, find_packages
 from sys import path as sys_path
 
 deps = [
-    "pymp4", "click", "clickutil"
+    "pymp4",
+    "click",
+    "clickutil",
 ]
 
 srcdir = join(dirname(abspath(__file__)), "src/")

--- a/src/blackclue/blackclue.py
+++ b/src/blackclue/blackclue.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from __future__ import print_function
+
 import io
 import logging
-import click
 import os
 
+import click
 import clickutil
-from pymp4.parser import Box
 import construct
+from pymp4.parser import Box
 
 log = logging.getLogger(__name__)
 construct.setglobalfullprinting(True)

--- a/src/blackclue/blackclue.py
+++ b/src/blackclue/blackclue.py
@@ -6,6 +6,7 @@ import logging
 import click
 import os
 
+import clickutil
 from pymp4.parser import Box
 import construct
 
@@ -23,16 +24,6 @@ emb_file_def = {
 }
 
 
-@click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('-c', '--dump-embedded', is_flag=True,
-              help='Dump complete embedded data.')
-@click.option('-r', '--dump-raw-blocks', is_flag=True,
-              help='Dump raw blocks from embedded data.')
-@click.option('-x', '--extended-scan', is_flag=True,
-              help='Do not stop scanning file after processing the embedded data.')
-@click.option('-v', '--verbose', is_flag=True,
-              help='Print some additional information.')
-@click.argument('FILE', nargs=-1, metavar='filelist')
 def dump(file, dump_embedded, dump_raw_blocks, extended_scan, verbose):
     """ Extract GPS and Acceleration data from BlackVue MP4 recordings.
 
@@ -121,4 +112,17 @@ def dump(file, dump_embedded, dump_raw_blocks, extended_scan, verbose):
 
 
 if __name__ == '__main__':
-    dump()
+    @click.command(context_settings=dict(help_option_names=['-h', '--help']))
+    @click.option('-c', '--dump-embedded', is_flag=True,
+                  help='Dump complete embedded data.')
+    @click.option('-r', '--dump-raw-blocks', is_flag=True,
+                  help='Dump raw blocks from embedded data.')
+    @click.option('-x', '--extended-scan', is_flag=True,
+                  help='Do not stop scanning file after processing the embedded data.')
+    @click.option('-v', '--verbose', is_flag=True,
+                  help='Print some additional information.')
+    @click.argument('FILE', nargs=-1, metavar='filelist')
+    @clickutil.call(dump)
+    def _dump():
+        pass
+    _dump()


### PR DESCRIPTION
As a thankful user of your ``blackclue`` library I would like to use it from within Python, instead of as a command line utility only. I have used ``clickutil`` to do so. Would you consider merging these changes?