### PR TITLE
Add explicit requirement of construct in a git merge-friendly way

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ from setuptools import setup, find_packages
 from sys import path as sys_path
 
 deps = [
-    "pymp4", "click"
+    "pymp4",
+    "click",
+    "construct",
 ]
 
 srcdir = join(dirname(abspath(__file__)), "src/")


### PR DESCRIPTION
Currently ``blackclue`` gets its installation of ``construct`` because ``pymp4`` has it listed as a dependency. Relying on that feels a bit tricky, especially since [``pymp4`` is considering using something else instead of ``construct``](https://github.com/beardypig/pymp4/issues/3).