### PR TITLE
Fix "Module not found" on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,7 @@ from setuptools import setup, find_packages
 from sys import path as sys_path
 
 deps = [
-    "pymp4",
-    "click",
-    "clickutil",
+    "pymp4", "click", "clickutil"
 ]
 
 srcdir = join(dirname(abspath(__file__)), "src/")

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(name="blackclue",
       entry_points={
           "console_scripts": ["blackclue=blackclue:dump_cli"]
       },
+      py_modules=["blackclue"],
       install_requires=deps,
       # test_suite="tests",
       classifiers=["Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ from setuptools import setup, find_packages
 from sys import path as sys_path
 
 deps = [
-    "pymp4", "click", "clickutil"
+    "pymp4",
+    "click",
+    "clickutil",
 ]
 
 srcdir = join(dirname(abspath(__file__)), "src/")


### PR DESCRIPTION
This should fix issue #3 by registering the module in ``setup.py``, under ``py_modules``.

> blackclue.exe sounds like you made an executable from the python script. Maybe the packaging did not include all files. If this is the case, please refer to the packager documentation on how to proceed.

Building a ``.exe`` is actually a thing Python for Windows does to register executables on the path.